### PR TITLE
Adds Dice so nice roll without message and applies it to Token Target Helper saving throw

### DIFF
--- a/src/features/target.js
+++ b/src/features/target.js
@@ -8,7 +8,7 @@ import {
 } from "../shared/flags";
 import { createChoicesHook, createHook } from "../shared/hook";
 import { localize, subLocalize } from "../shared/localize";
-import { getInMemory, setInMemory } from "../shared/misc";
+import { deleteInMemory, getInMemory, setInMemory } from "../shared/misc";
 import { warn } from "../shared/notification";
 import { templatePath } from "../shared/path";
 import {
@@ -617,10 +617,20 @@ async function getTargetFromEvent(event) {
 	return fromUuid(targetUuid);
 }
 
+function isRollingSave(message, target) {
+	return getInMemory(message, `target.save.${target.id}`);
+}
+
+function setRollingSave(message, target) {
+	setInMemory(message, `target.save.${target.id}`, true);
+}
+
 async function rerollSave(event, message, { dc }) {
 	const target = await getTargetFromEvent(event);
 	const actor = target?.actor;
 	if (!actor) return;
+
+	if (isRollingSave(message, target)) return;
 
 	const flag = getFlag(message, `target.saves.${target.id}`);
 	if (!flag?.roll || flag.rerolled) return;
@@ -681,6 +691,8 @@ async function rerollSave(event, message, { dc }) {
 		});
 	}
 
+	setRollingSave(message, target);
+
 	const oldRoll = Roll.fromJSON(flag.roll);
 	const unevaluatedNewRoll = oldRoll.clone();
 	unevaluatedNewRoll.options.isReroll = true;
@@ -694,7 +706,7 @@ async function rerollSave(event, message, { dc }) {
 
 	const newRoll = await unevaluatedNewRoll.evaluate({ async: true });
 	await roll3dDice(newRoll);
-	
+
 	Hooks.callAll(
 		"pf2e.reroll",
 		Roll.fromJSON(flag.roll),
@@ -749,8 +761,12 @@ async function rollSave(event, message, { dc, statistic }) {
 	const actor = target?.actor;
 	if (!actor) return;
 
+	if (isRollingSave(message, target)) return;
+
 	const save = actor.saves[statistic];
 	if (!save) return;
+
+	setRollingSave(message, target);
 
 	const item = (() => {
 		const item = message.item;
@@ -803,16 +819,18 @@ async function rollSave(event, message, { dc, statistic }) {
 	});
 }
 
-function updateMessageSave({ message, target, data }) {
+async function updateMessageSave({ message, target, data }) {
 	if (typeof message === "string") {
 		message = game.messages.get(message);
 		if (!message) return;
 	}
 
-	if (typeof data.success === "number")
+	if (typeof data.success === "number") {
 		data.success = DEGREE_OF_SUCCESS[data.success];
+	}
 
-	setFlag(message, `target.saves.${target}`, deepClone(data));
+	await setFlag(message, `target.saves.${target}`, deepClone(data));
+	deleteInMemory(message, `target.save.${target}`);
 }
 
 async function openTargetSheet(event) {

--- a/src/features/target.js
+++ b/src/features/target.js
@@ -1,4 +1,5 @@
 import { bindOnPreCreateSpellDamageChatMessage } from "../shared/chat";
+import { roll3dDice } from "../shared/dicesonice";
 import {
 	getFlag,
 	moduleFlagUpdate,
@@ -692,6 +693,8 @@ async function rerollSave(event, message, { dc }) {
 	);
 
 	const newRoll = await unevaluatedNewRoll.evaluate({ async: true });
+	await roll3dDice(newRoll);
+	
 	Hooks.callAll(
 		"pf2e.reroll",
 		Roll.fromJSON(flag.roll),
@@ -775,7 +778,8 @@ async function rollSave(event, message, { dc, statistic }) {
 		origin: actor,
 		skipDialog: event.shiftKey ? !skipDefault : skipDefault,
 		createMessage: false,
-		callback: (roll, __, msg) => {
+		callback: async (roll, __, msg) => {
+			await roll3dDice(roll);
 			packet.data = {
 				value: roll.total,
 				die: roll.dice[0].total,

--- a/src/shared/dicesonice.js
+++ b/src/shared/dicesonice.js
@@ -1,7 +1,7 @@
-export async function roll3dDice(roll){
+export async function roll3dDice(roll, user = game.user, synchronize = true){
     // if DSN is active and doesn't display chat card immediately, delay until the roll is done
     if(game.modules.get('dice-so-nice')?.active){
-        let dsnRoll = game.dice3d.showForRoll(roll);
+        let dsnRoll = game.dice3d.showForRoll(roll, user, synchronize);
         if(!game.settings.get("dice-so-nice", "immediatelyDisplayChatMessages")){
             return dsnRoll;
         } 

--- a/src/shared/dicesonice.js
+++ b/src/shared/dicesonice.js
@@ -1,0 +1,10 @@
+export async function roll3dDice(roll){
+    // if DSN is active and doesn't display chat card immediately, delay until the roll is done
+    if(game.modules.get('dice-so-nice')?.active){
+        let dsnRoll = game.dice3d.showForRoll(roll);
+        if(!game.settings.get("dice-so-nice", "immediatelyDisplayChatMessages")){
+            return dsnRoll;
+        } 
+    }
+    return Promise.resolve(true);
+}

--- a/src/shared/dicesonice.js
+++ b/src/shared/dicesonice.js
@@ -1,10 +1,7 @@
-export async function roll3dDice(roll, user = game.user, synchronize = true){
-    // if DSN is active and doesn't display chat card immediately, delay until the roll is done
-    if(game.modules.get('dice-so-nice')?.active){
-        let dsnRoll = game.dice3d.showForRoll(roll, user, synchronize);
-        if(!game.settings.get("dice-so-nice", "immediatelyDisplayChatMessages")){
-            return dsnRoll;
-        } 
-    }
-    return Promise.resolve(true);
+export async function roll3dDice(
+	roll,
+	{ user = game.user, synchronize = true } = {},
+) {
+	if (!game.modules.get("dice-so-nice")?.active) return;
+	return game.dice3d.showForRoll(roll, user, synchronize);
 }


### PR DESCRIPTION
I didn't like how Token Target Helper saving throw didn't interact with DSN, so I've used their showForRoll method to roll 3d dice after the result is calculated. It respects DSN setting to update chat before the 3d roll finishes.

Since I'm not sure how to build your module, I couldn't test it in a built state. But the function works as a standalone.