### PR TITLE
Fix template path for "removeActions"

### DIFF
--- a/src/tools/hero-actions/tool.ts
+++ b/src/tools/hero-actions/tool.ts
@@ -272,7 +272,7 @@ class HeroActionsTool extends ModuleTool<HeroActionsSettings> {
 
         const result = await waitDialog<{ actor: (string | null)[] }>({
             classes: ["pf2e-toolbelt-heroActions-remove"],
-            content: this.path("removeActions"),
+            content: this.templatePath("removeActions"),
             data: {
                 actors: game.actors.filter((actor) => actor.isOfType("character")),
             },


### PR DESCRIPTION
The `removeHeroActions()` was not working as it was using `this.path("removeActions")` instead of `this.templatePath("removeActions")` for `content:`