### PR TITLE
Spell anonymizing fixes

### DIFF
--- a/src/tools/anonymous.ts
+++ b/src/tools/anonymous.ts
@@ -201,7 +201,7 @@ function partyKnowsSpell(spell: SpellPF2e): CreaturePF2e[] {
                 entry.category !== "prepared" ||
                 (entry.system?.prepared?.flexible && item.system?.location?.signature) ||
                 R.values(entry.system?.slots ?? ({} as SpellcastingEntrySlots)).some((slot) => {
-                    slot.prepared.some((prepared) => prepared.id === spellId);
+                    return slot.prepared.some((prepared) => prepared.id === spellId);
                 })
             );
         });

--- a/src/tools/anonymous.ts
+++ b/src/tools/anonymous.ts
@@ -218,7 +218,8 @@ function isValidCoreSpellMessage(message: ChatMessagePF2e): message is ChatMessa
 function isValidSpellMessage(message: ChatMessagePF2e): message is ChatMessagePF2e & { item: SpellPF2e } {
     return (
         !!message.item?.isOfType("spell") &&
-        R.isIncludedIn(message.flags[SYSTEM.id].context?.type, ["spell-cast", "damage-roll"])
+        (message.flags[SYSTEM.id].origin?.type === "spell" ||
+        R.isIncludedIn(message.flags[SYSTEM.id].context?.type, ["spell-cast", "damage-roll"]))
     );
 }
 

--- a/src/tools/anonymous.ts
+++ b/src/tools/anonymous.ts
@@ -199,6 +199,7 @@ function partyKnowsSpell(spell: SpellPF2e): CreaturePF2e[] {
 
             return (
                 entry.category !== "prepared" ||
+                (entry.system?.prepared?.flexible && item.system?.location?.signature) ||
                 R.values(entry.system?.slots ?? ({} as SpellcastingEntrySlots)).some((slot) => {
                     slot.prepared.some((prepared) => prepared.id === spellId);
                 })


### PR DESCRIPTION
Fixes a few issues:
- Some NPC spells aren't being anonymized. It seems to miss any spell that has no built-in damage or save (example: [Prestidigitation](https://2e.aonprd.com/Spells.aspx?ID=1639)).
- Prepared spellcasting isn't revealing spells.
- When the `Flexible` option is checked in a prepared spellcasting entry for a PC, spell slots will always be empty, and the spells marked as signature spells are what is actually prepared.