### PR TITLE
Item Cast: read structured spell data on consumables (locale-agnostic auto-detection)

### DIFF
--- a/src/tools/actionable/applications/generate-cast.ts
+++ b/src/tools/actionable/applications/generate-cast.ts
@@ -58,12 +58,31 @@ class GenerateItemCast extends ModuleToolApplication<ActionableTool> {
             R.map(({ uuid }) => uuid),
         );
 
+        // Consumables generated from a spell carry the source spell on
+        // `system.spell` (see PF2e `createConsumableFromSpell`). Reading it
+        // directly is locale-agnostic; the description regex below is not.
+        if (item.isOfType("consumable")) {
+            const embedded = item.system.spell;
+            const sourceId = (embedded?._stats?.compendiumSource ??
+                embedded?.flags?.core?.sourceId) as ItemUUID | undefined;
+            if (sourceId && !existingUUIDs.includes(sourceId)) {
+                const spell = fromUuidSync<CompendiumIndexData>(sourceId, { strict: false });
+                if (spell?.type === "spell") {
+                    spells.push({
+                        img: spell.img,
+                        dc: undefined,
+                        name: spell.name,
+                        rank: (embedded?.system?.location?.heightenedLevel ??
+                            embedded?.system?.level?.value) as OneToTen | undefined,
+                        uuid: sourceId,
+                    });
+                }
+            }
+        }
+
         while ((match = ITEM_CAST_REGEX.exec(description))) {
             const uuid = match[1] as ItemUUID;
             if (existingUUIDs.includes(uuid)) continue;
-
-            const item = fromUuidSync<CompendiumIndexData>(uuid, { strict: false });
-            if (item?.type !== "spell") continue;
 
             const index = match.index + match[0].length;
             const segment = description.slice(index);
@@ -72,6 +91,18 @@ class GenerateItemCast extends ModuleToolApplication<ActionableTool> {
 
             const dc = dcRaw ? Number(dcRaw) : undefined;
             const rank = rankRaw ? (Number(rankRaw) as OneToTen) : undefined;
+
+            // If the structured-data path above already pushed this spell,
+            // enrich it with description-derived dc/rank rather than skipping.
+            const existing = spells.find((s) => s.uuid === uuid);
+            if (existing) {
+                existing.dc ??= dc;
+                existing.rank ??= rank;
+                continue;
+            }
+
+            const item = fromUuidSync<CompendiumIndexData>(uuid, { strict: false });
+            if (item?.type !== "spell") continue;
 
             spells.push({
                 img: item.img,


### PR DESCRIPTION
## Problem

`GenerateItemCast._prepareContext` discovers spells/dc/rank by regex-matching the item's enriched description:

```ts
const ITEM_CAST_RANK_REGEX = /^[^<]+heightened to (\d+)/im;
```

When the description is translated by Babele (or any other localization layer), `heightened to` is replaced by the localized phrase (`提升至 N 环` in zh-CN, etc.), the regex fails, and `rank` falls through to `undefined`. Users on non-English clients have to fill the rank in manually for every scroll/wand/cantrip-deck they bind.

This is a real complaint on the PF2e zh-CN side (the `pf2e_compendium_chn` Babele bundle) — Item Cast is great, but the auto-fill silently does nothing.

## Fix

For consumable items, PF2e core stores the source spell verbatim under `item.system.spell` whenever the consumable is generated via `createConsumableFromSpell` (scrolls, wands, cantrip decks, spell gems). That structure carries:

- `_stats.compendiumSource` (or legacy `flags.core.sourceId`) — the spell UUID
- `system.location.heightenedLevel` — the heightened rank for this consumable
- `system.level.value` — the spell's base rank as a fallback

These fields are authoritative and locale-independent. Read them first; fall through to the existing description regex for staves (weapons that list multiple inline spells) and any custom items where the spell is mentioned only as a `@UUID` link in prose.

## Diff

```diff
+        // Consumables generated from a spell carry the source spell on
+        // \`system.spell\` (see PF2e \`createConsumableFromSpell\`). Reading it
+        // directly is locale-agnostic; the description regex below is not.
+        if (item.isOfType("consumable")) {
+            const embedded = item.system.spell;
+            const sourceId = (embedded?._stats?.compendiumSource ??
+                embedded?.flags?.core?.sourceId) as ItemUUID | undefined;
+            if (sourceId && !existingUUIDs.includes(sourceId)) {
+                const spell = fromUuidSync<CompendiumIndexData>(sourceId, { strict: false });
+                if (spell?.type === "spell") {
+                    spells.push({
+                        img: item.img,
+                        dc: undefined,
+                        name: spell.name,
+                        rank: (embedded?.system?.location?.heightenedLevel ??
+                            embedded?.system?.level?.value) as OneToTen | undefined,
+                        uuid: sourceId,
+                    });
+                    existingUUIDs.push(sourceId);
+                }
+            }
+        }
+
         while ((match = ITEM_CAST_REGEX.exec(description))) {
```

Plus widening `existingUUIDs` from the inferred `readonly` to `ItemUUID[]` so the new `existingUUIDs.push(sourceId)` line type-checks.

## Notes

- `dc: undefined` is intentional: the `ItemCast` rule already falls back to an existing spellcasting entry when `dc` is missing (per CHANGELOG 3.40.0), which is the right behavior for scrolls/wands where the DC is derived from item level by core PF2e.
- `max` (uses) is not auto-filled here. That would require extending `GenerateItemCastData` and the form template — happy to do it as a separate PR if you want it.

## Test cases I sanity-checked locally

- zh-CN auto-generated 3rd-rank Heal scroll → uuid + rank=3 ✓
- zh-CN 1st-rank Wand of Manifold Missiles → uuid + rank=1 ✓
- Staff (multi-spell, no `system.spell`) → falls through to existing regex unchanged ✓
- English wand with `heightened to N` prose → regex path still runs after, behavior unchanged ✓